### PR TITLE
adds one redirect for mdi.ucsf.edu to pharmacy.ucsf.edu/qbi which is …

### DIFF
--- a/rules.tsv
+++ b/rules.tsv
@@ -576,4 +576,5 @@ smdc.ucsf.edu/screening/scale.htm	https://pharm.ucsf.edu/smdc/tech-services/hts-
 smdc.ucsf.edu/sitemap.htm	https://pharm.ucsf.edu/smdc
 smdc.ucsf.edu/index.htm	https://pharm.ucsf.edu/smdc
 smdc.ucsf.edu	https://pharm.ucsf.edu/smdc
+mdi.ucsf.edu https://pharmacy.ucsf.edu/qbi
 spitalist.ucsf.edu


### PR DESCRIPTION
…related to the School of Pharmacy